### PR TITLE
Fix width adjustment when newWidths is empty

### DIFF
--- a/MMTabBarView/MMTabBarView/MMTabBarController.m
+++ b/MMTabBarView/MMTabBarView/MMTabBarController.m
@@ -380,7 +380,7 @@ static NSInteger potentialMinimumForArray(NSArray *array, NSInteger minimum){
                             totalOccupiedWidth += revisedWidth;
                         }
 
-                        if (totalOccupiedWidth < availableWidth) {
+                        if (totalOccupiedWidth < availableWidth && [newWidths count] > 0) {
                             // when the available width is not divided evenly by totalOccupiedWidth
                             // there will be a small gap between the addTab-button and the left-most tab
                             // here we distribute the remainder among the tabs.


### PR DESCRIPTION
I tried the demo app, and it hung when I tried to select the Sierra tab style. This fixes it.